### PR TITLE
Support for shoryuken background job processor and logging to stdout

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,6 +25,6 @@ Style/FrozenStringLiteralComment:
   Exclude:
     - gemfiles/**/*
 
-Layout/AlignHash:
+Layout/HashAlignment:
   EnforcedColonStyle: table
   EnforcedHashRocketStyle: table

--- a/Appraisals
+++ b/Appraisals
@@ -2,8 +2,10 @@
 
 appraise "rails5.2" do
   gem "rails", "~>5.2.0"
+  gem 'sprockets', '~>3.0'
 end
 
 appraise "rails6.0" do
   gem "rails", "~>6.0.0"
+  gem 'sprockets', '~>3.0'
 end

--- a/Appraisals
+++ b/Appraisals
@@ -2,10 +2,10 @@
 
 appraise "rails5.2" do
   gem "rails", "~>5.2.0"
-  gem 'sprockets', '~>3.0'
+  gem "sprockets", "~>3.0"
 end
 
 appraise "rails6.0" do
   gem "rails", "~>6.0.0"
-  gem 'sprockets', '~>3.0'
+  gem "sprockets", "~>3.0"
 end

--- a/gemfiles/rails5.2.gemfile
+++ b/gemfiles/rails5.2.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", "5.2.0"
+gem "rails", "~>5.2.0"
+gem "sprockets", "~>3.0"
 
 gemspec path: "../"

--- a/gemfiles/rails6.0.gemfile
+++ b/gemfiles/rails6.0.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", "6.0.0"
+gem "rails", "~>6.0.0"
+gem "sprockets", "~>3.0"
 
 gemspec path: "../"

--- a/lib/loggery.rb
+++ b/lib/loggery.rb
@@ -10,14 +10,20 @@ require "loggery/util"
 require "loggery/controller/logging_context"
 require "loggery/sidekiq/setup"
 require "loggery/sidekiq/sidekiq_exception_logger"
+require "loggery/shoryuken/setup"
 require "loggery/metadata/logstash_event_util"
 require "loggery/metadata/store"
 require "loggery/metadata/middleware/rack"
 require "loggery/metadata/middleware/sidekiq"
+require "loggery/metadata/middleware/shoryuken"
 require "loggery/railtie"
 
 module Loggery
   def self.setup_sidekiq
     Loggery::Sidekiq::Setup.setup
+  end
+
+  def self.setup_shoryuken
+    Loggery::Shoryuken::Setup.setup
   end
 end

--- a/lib/loggery/metadata/middleware/shoryuken.rb
+++ b/lib/loggery/metadata/middleware/shoryuken.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+# Shoryuken middleware that adds basic metadata to all log lines.
+
+module Loggery
+  module Metadata
+    module Middleware
+      class Shoryuken
+        include Loggery::Util
+
+        # Clients can provide their own error handler
+        class << self
+          attr_accessor(:error_handler) { ->(e) { Rails.logger.error(e) } }
+        end
+
+        def call(worker_instance, queue, sqs_msg, body)
+          Loggery::Metadata::Store.with_metadata(build_metadata(queue, body)) do
+            job_instance_name = "#{body['job_class']} (#{body['arguments']})"
+            log_job_start(body, job_instance_name)
+
+            log_job_runtime(:shoryuken_job, job_instance_name) do
+              yield
+            rescue StandardError => e
+              # Log exceptions here, otherwise they won't have the metadata available anymore by
+              # the time they reach the Shoryuken default error handler.
+              self.class.error_handler&.call(e)
+              raise e
+            end
+          end
+        end
+
+        private
+
+        def build_metadata(queue, body)
+          {
+            jid:         body["job_id"],
+            thread_id:   Thread.current.object_id.to_s(36),
+            job_class:   body["job_class"],
+            arguments:   body["arguments"].inspect,
+            queue:       queue,
+            executions:   body["executions"],
+            worker_type: "shoryuken",
+          }
+        end
+
+        def log_job_start(body, job_instance_name)
+          execution_delay =
+            (Time.current - Time.zone.parse(body["enqueued_at"]) if body["enqueued_at"])
+
+          Rails.logger.info(
+            event_type:      :shoryuken_job_started,
+            message:         "Job type shoryuken_job - #{job_instance_name} started",
+            execution_delay: execution_delay
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/loggery/metadata/middleware/shoryuken.rb
+++ b/lib/loggery/metadata/middleware/shoryuken.rb
@@ -8,8 +8,8 @@ module Loggery
       class Shoryuken
         include Loggery::Util
 
-        # Clients can provide their own error handler
         class << self
+          # Clients can provide their own error handler
           attr_accessor(:error_handler) { ->(e) { Rails.logger.error(e) } }
         end
 

--- a/lib/loggery/metadata/middleware/shoryuken.rb
+++ b/lib/loggery/metadata/middleware/shoryuken.rb
@@ -13,7 +13,7 @@ module Loggery
           attr_accessor(:error_handler) { ->(e) { Rails.logger.error(e) } }
         end
 
-        def call(worker_instance, queue, sqs_msg, body)
+        def call(_worker_instance, queue, _sqs_msg, body)
           Loggery::Metadata::Store.with_metadata(build_metadata(queue, body)) do
             job_instance_name = "#{body['job_class']} (#{body['arguments']})"
             log_job_start(body, job_instance_name)
@@ -38,8 +38,8 @@ module Loggery
             job_class:   body["job_class"],
             arguments:   body["arguments"].inspect,
             queue:       queue,
-            executions:   body["executions"],
-            worker_type: "shoryuken",
+            executions:  body["executions"],
+            worker_type: "shoryuken"
           }
         end
 

--- a/lib/loggery/railtie.rb
+++ b/lib/loggery/railtie.rb
@@ -6,8 +6,8 @@ require "rails/rack/logger"
 module Loggery
   module LogstashSetup
     def self.setup(config)
-      config.logstash.type = :file
-      config.logstash.path = config.loggery.log_file
+      config.logstash.type = config.loggery.log_type
+      config.logstash.path = config.loggery.log_file if config.loggery.log_type == :file
 
       LogStashLogger.configure do |logstash|
         logstash.customize_event do |event|
@@ -44,6 +44,7 @@ module Loggery
 
     # Default options
     config.loggery.enabled = true
+    config.loggery.log_type = :file
     config.loggery.log_file = "log/logstash-#{Rails.env}.log"
 
     initializer :loggery, before: :logstash_logger do |app|

--- a/lib/loggery/shoryuken/setup.rb
+++ b/lib/loggery/shoryuken/setup.rb
@@ -5,8 +5,6 @@ module Loggery
     module Setup
       def self.setup
         ::Shoryuken.configure_server do |config|
-          config.logger = Rails.logger
-
           config.server_middleware do |chain|
             chain.add Loggery::Metadata::Middleware::Shoryuken
           end

--- a/lib/loggery/shoryuken/setup.rb
+++ b/lib/loggery/shoryuken/setup.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Loggery
+  module Shoryuken
+    module Setup
+      def self.setup
+        ::Shoryuken.configure_server do |config|
+          config.logger = Rails.logger
+
+          config.server_middleware do |chain|
+            chain.add Loggery::Metadata::Middleware::Shoryuken
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/loggery/metadata/middleware/shoryuken_spec.rb
+++ b/spec/loggery/metadata/middleware/shoryuken_spec.rb
@@ -4,11 +4,11 @@ require "spec_helper"
 
 describe Loggery::Metadata::Middleware::Shoryuken do
   let(:body) do
-    { 
-      "job_class" => "MyWorker",
-      "arguments" => [ "foo", "bar" ],
+    {
+      "job_class"   => "MyWorker",
+      "arguments"   => %w[foo bar],
       "enqueued_at" => "2020-07-13T14:25:01Z",
-      "executions" => 0
+      "executions"  => 0
     }
   end
 

--- a/spec/loggery/metadata/middleware/shoryuken_spec.rb
+++ b/spec/loggery/metadata/middleware/shoryuken_spec.rb
@@ -49,12 +49,6 @@ describe Loggery::Metadata::Middleware::Shoryuken do
       end
 
       it "logs and re-raises the exception with correct metadata" do
-        allow(Rails.logger).to receive(:info)
-          .with(event_type: :shoryuken_job_started, message: anything, execution_delay: anything)
-          .and_call_original
-        allow(Rails.logger).to receive(:info)
-          .with(event_type: :shoryuken_job_finished, message: anything, duration: anything)
-          .and_call_original
         expect(Rails.logger).to receive(:error).and_call_original
         expect(Loggery::Metadata::LogstashEventUtil).to receive(:event_metadata) {
           expect(Loggery::Metadata::Store.store.keys).to eq %i[

--- a/spec/loggery/metadata/middleware/shoryuken_spec.rb
+++ b/spec/loggery/metadata/middleware/shoryuken_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Loggery::Metadata::Middleware::Shoryuken do
+  let(:body) do
+    { 
+      "job_class" => "MyWorker",
+      "arguments" => [ "foo", "bar" ],
+      "enqueued_at" => "2020-07-13T14:25:01Z",
+      "executions" => 0
+    }
+  end
+
+  describe "#call" do
+    it "stores data relevant for logging in RequestStore and makes it available within the block" do
+      subject.call(nil, "critical", nil, body) do
+        expect(Loggery::Metadata::Store.store).to include(
+          jid:         anything,
+          thread_id:   anything,
+          job_class:   "MyWorker",
+          arguments:   '["foo", "bar"]',
+          queue:       "critical",
+          executions:  0,
+          worker_type: "shoryuken"
+        )
+      end
+    end
+
+    it "logs the execution delay and duration of the shoryuken request" do
+      expect(Rails.logger).to receive(:info)
+        .with(event_type:      :shoryuken_job_started,
+              message:         'Job type shoryuken_job - MyWorker (["foo", "bar"]) started',
+              execution_delay: anything)
+        .and_call_original
+      expect(Rails.logger).to receive(:info)
+        .with(event_type: :shoryuken_job_finished,
+              message:    'Job type shoryuken_job - MyWorker (["foo", "bar"]) finished',
+              duration:   anything)
+        .and_call_original
+      subject.call(nil, "critical", nil, body) {}
+    end
+
+    context "when the block raises an exception" do
+      around(:each) do |example|
+        Loggery::Metadata::Middleware::Shoryuken.error_handler = ->(_e) { Rails.logger.error("test") }
+        example.run
+        Loggery::Metadata::Middleware::Shoryuken.error_handler = nil
+      end
+
+      it "logs and re-raises the exception with correct metadata" do
+        allow(Rails.logger).to receive(:info)
+          .with(event_type: :shoryuken_job_started, message: anything, execution_delay: anything)
+          .and_call_original
+        allow(Rails.logger).to receive(:info)
+          .with(event_type: :shoryuken_job_finished, message: anything, duration: anything)
+          .and_call_original
+        expect(Rails.logger).to receive(:error).and_call_original
+        expect(Loggery::Metadata::LogstashEventUtil).to receive(:event_metadata) {
+          expect(Loggery::Metadata::Store.store.keys).to eq %i[
+            jid
+            thread_id
+            job_class
+            arguments
+            queue
+            executions
+            worker_type
+          ]
+        }.at_least(3).times
+
+        expect do
+          subject.call(nil, "critical", nil, body) { raise "boom!" }
+        end.to raise_error "boom!"
+      end
+    end
+  end
+end


### PR DESCRIPTION
👋 Hi Lieferies! 😀

I'm using `loggery-gem` on my current project and have added 2 changes:

1. support for the [shoryuken](https://github.com/phstc/shoryuken) background processor (sidekiq-clone for AWS SQS)
2. support for different LogstashLogger log-types to support logging to stdout, like us docker-kids do

Let me know if you're ok with this and I'm also happy to do a version bump and publish the gem. I think I'm still the maintainer for that anyway ;-)

Simon